### PR TITLE
feat(wrap): Include wrap-reverse value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # History
 
+## Unreleased
+
+### Enhancements
+* Include `wrap-reverse` for `wrap` property
+
 ## 0.1.0
 
 The dawn of time.

--- a/src/Flex/types.ts
+++ b/src/Flex/types.ts
@@ -12,6 +12,4 @@ export type FlexDirection = Property.FlexDirection | undefined;
 
 export type JustifyContent = Property.JustifyContent | undefined;
 
-// NOTE: 'wrap-reverse' is omitted because it is not in our existing patterns.
-// Can discuss with design if it becomes necessary.
-export type FlexWrap = Exclude<Property.FlexWrap, "wrap-reverse"> | undefined;
+export type FlexWrap = Property.FlexWrap | undefined;


### PR DESCRIPTION
This is really useful for responsive designs. Don't see a big reason to keep this excluded.
